### PR TITLE
Prepare for dart_dev v4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
 
 dev_dependencies:
   dependency_validator: ^3.2.2
-  dart_dev: ^3.9.2
+  dart_dev: '>=3.9.2 <5.0.0'
   glob: ^2.1.1


### PR DESCRIPTION
This PR widens the allowable version ranges of dart_dev so that all repos at Workiva can consume dart_dev 4.0.0 without updating all repositories in lock step.
For more info, reach out to Timothy Steward or `#link23-state-of-the-dart-jam` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dev_widen_ranges_v4`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dev_widen_ranges_v4)