### PR TITLE
RM-187414 Release scip-dart 1.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.0.5
+version: 1.0.6
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-1671: Improved package version calculation](https://github.com/Workiva/scip-dart/pull/30)
	* [FEA-1676: Prep for open source release](https://github.com/Workiva/scip-dart/pull/31)
	* [FEA-1741: Correctly index fields](https://github.com/Workiva/scip-dart/pull/32)
	* [FEA-1745: Added license](https://github.com/Workiva/scip-dart/pull/33)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.0.5...Workiva:release_scip-dart_1.0.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.0.5...1.0.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=34)