### PR TITLE
FEA-1767: Updates for pub publish

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   format:
-    runs-on: workiva-runner-dev
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -15,7 +15,7 @@ jobs:
       - run: dart run dart_dev format
 
   dependency-validator:
-    runs-on: workiva-runner-dev
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
       # Setup scip-dart
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
-      - uses: Workiva/gha-dart/pub-get@master
+      - uses: dart pub get
 
       # Setup repo to run on
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
       # Setup scip-dart
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
-      - uses: dart pub get
+      - run: dart pub get
 
       # Setup repo to run on
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.6
+
+- Initial open sourcing of repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,1 @@
-FROM google/dart:2
-WORKDIR /build/
-ADD pubspec.yaml /build
-RUN dart pub get
-FROM scratch
+FROM drydock-prod.workiva.net/workiva/dart_build_image:3 as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,5 @@
-FROM drydock-prod.workiva.net/workiva/dart_build_image:3 as build
+FROM google/dart:2
+WORKDIR /build/
+ADD pubspec.yaml /build
+RUN dart pub get
+FROM scratch

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Designed to be a replacement for [lsif_indexer](https://github.com/Workiva/lsif_
 ## Installation
 
 ```sh
-dart pub global activate --hosted-url https://pub.workiva.org scip_dart
+dart pub global activate scip_dart
 ```
 
 ## Usage
@@ -41,11 +41,3 @@ Analysis can be uploaded to sourcegraph using the [src cli](https://docs.sourceg
 ```sh
 src code-intl upload -file=index.scip -github-token="<your gh token>"
 ```
-
-## Design Philosophy
-
-Scip is a fairly simple file format. Much of it boils down to finding every declaration in a source file, and creating a unique, but consistent string for it. This is called a `symbol`. Then the idea is to search the source code for every reference, and generate that same `symbol` we created before, for the references declaration. After this is done, we should have a large mapping of every reference, and declaration which allows external tools to preform code navigation on the entities within the codebase.
-
-While this is simple in concept, in practice, parsing ast, and generating these symbols is edge case hell. Instead of expecting full coverage on everything, in its spike state, `scip-dart` will fail silently on unknown cases (this silent failing can be turned off with the `--verbose/-v` flag). The reason for this is that an incomplete scip index is still helpful, but a completely failed indexing is not.
-
-Failures in running `scip-dart` will be treated with higher priority than full coverage of symbols.

--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -1,0 +1,2 @@
+exclude:
+  - snapshots/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,3 @@ dev_dependencies:
   dependency_validator: ^3.2.2
   dart_dev: '>=3.9.2 <5.0.0'
   glob: ^2.1.1
-
-dependency_validator:
-  exclude:
-    - snapshots/**


### PR DESCRIPTION
In order for `dart pub publish` to work, we need a changelog, and dep validator cannot showup within the pubspec.yaml

Made these changes, and also updated the readme with the new method for installing pub (once that is available)