### PR TITLE
Release scip-dart 1.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.0.6
+version: 1.1.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-1767: Updates for pub publish](https://github.com/Workiva/scip-dart/pull/35)
	* [FEA-1781: Avoid indexing synthetic functions with no definition](https://github.com/Workiva/scip-dart/pull/38)
	* [FEA-1976: Added dependabot](https://github.com/Workiva/scip-dart/pull/41)
	* [FEA-1986: Deprecate `-p`/`--path`](https://github.com/Workiva/scip-dart/pull/44)
	* [Bump pubspec_parse from 1.2.1 to 1.2.3](https://github.com/Workiva/scip-dart/pull/46)
	* [Bump args from 2.4.0 to 2.4.1](https://github.com/Workiva/scip-dart/pull/47)
	* [Bump glob from 2.1.1 to 2.1.2](https://github.com/Workiva/scip-dart/pull/49)
	* [Bump dart_dev from 3.9.2 to 4.0.0](https://github.com/Workiva/scip-dart/pull/50)
	* [Bump args from 2.4.1 to 2.4.2](https://github.com/Workiva/scip-dart/pull/54)
	* [Bump dart_dev from 4.0.0 to 4.0.1](https://github.com/Workiva/scip-dart/pull/55)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.0.6...Workiva:release_scip-dart_1.1.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.0.6...1.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)