### PR TITLE
Preped CHANGELOG for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+- Fixed bug where the synthetic functions `loadLibrary` and `call` were indexed as references
+- Deprecated the --path flag in favor of running on all dart files in the package
+
 ## 1.0.6
 
 - Initial open sourcing of repo


### PR DESCRIPTION
OSS dart repos like to have an up to date changelog. Updated this for the 1.1.0 release