### PR TITLE
RM-199397 Release scip-dart 1.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.1.0
+version: 1.1.1
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* [Preped CHANGELOG for 1.1.0 release](https://github.com/Workiva/scip-dart/pull/58)
* [FEA-2048: Ignore nested subpackages](https://github.com/Workiva/scip-dart/pull/60)
* [Updated changelog for 1.1.1 release](https://github.com/Workiva/scip-dart/pull/61)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.1.0...Workiva:release_scip-dart_1.1.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.1.0...1.1.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=62)