### PR TITLE
RM-199946 Release scip-dart 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.2
+
+- added `--version` flag to retrieve the version of scip-dart
+- populated `ToolInfo.version` in resulting scip files
+
 ## 1.1.1
 
 - Fixed bug where running indexing on a dart package with a nested subpackage would throw an exception

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.1.1';
+const scipDartVersion = '1.1.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.1.1
+version: 1.1.2
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-2108: Populate ToolInfo Version](https://github.com/Workiva/scip-dart/pull/65)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.1.1...Workiva:release_scip-dart_1.1.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.1.1...1.1.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=66)