### PR TITLE
Fixed projectRoot URI calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ run:
 	dart run scip_dart ./snapshots/input/staging-project --verbose
 
 snap:
-	scip snapshot --to ./snapshots/output/staging-project
+	scip snapshot --project-root ./snapshots/input/staging-project --to ./snapshots/output/staging-project
 
 lint:
 	scip lint ./index.scip
+
+stats:
+	scip stats
 
 gen-proto:
 	protoc --dart_out=. ./lib/src/gen/scip.proto

--- a/lib/src/indexer.dart
+++ b/lib/src/indexer.dart
@@ -31,7 +31,7 @@ Future<Index> indexPackage(
   }
 
   final metadata = Metadata(
-    projectRoot: 'file:/' + dirPath,
+    projectRoot: Uri.file(dirPath).toString(),
     textDocumentEncoding: TextEncoding.UTF8,
     toolInfo: ToolInfo(
       name: 'scip-dart',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1"
   async:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:


### PR DESCRIPTION
`ProjectRoot` declared within the generated scip bindings was in the format of `file://path/to/root`, `file://` is an invalid uri, and needs to be in the format of `file:///`

This pr utilizes `Uri.file().toString` to correctly generate the necessary uri

Fixes the issue with running `scip stats` as reported here: https://github.com/sourcegraph/scip/issues/98