### PR TITLE
Put relationship indexing behind a flag

### DIFF
--- a/bin/scip_dart.dart
+++ b/bin/scip_dart.dart
@@ -11,6 +11,13 @@ import 'package:scip_dart/src/version.dart';
 Future<void> main(List<String> args) async {
   final result = (ArgParser()
         ..addFlag(
+          'index-relationships',
+          defaultsTo: false,
+          help: 'Whether or not to index symbol relationships. '
+                 'This functionality is currently in alpha, and should not be '
+                 'considered stable and accurate.',
+        )
+        ..addFlag(
           'performance',
           aliases: ['perf'],
           defaultsTo: false,
@@ -23,7 +30,7 @@ Future<void> main(List<String> args) async {
           help: 'Whether or not to display debugging text during indexing',
         )
         ..addFlag('version',
-            defaultsTo: false, help: 'Display the current version of scip-dart')
+            defaultsTo: false, help: 'Display the current version of scip-dart',)
         ..addMultiOption(
           'path',
           abbr: 'p',

--- a/lib/src/flags.dart
+++ b/lib/src/flags.dart
@@ -7,9 +7,13 @@ class Flags {
   bool get performance => _performance;
   bool _performance = false;
 
+  bool get indexRelationships => _indexRelationships;
+  bool _indexRelationships = false;
+
   void init(ArgResults results) {
     _verbose = results['verbose'] as bool? ?? false;
     _performance = results['performance'] as bool? ?? false;
+    _indexRelationships = results['index-relationships'] as bool? ?? false;
   }
 
   static Flags get instance => _instance;

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:package_config/package_config.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:scip_dart/src/flags.dart';
 import 'package:scip_dart/src/metadata.dart';
 import 'package:scip_dart/src/gen/scip.pb.dart';
 import 'package:scip_dart/src/relationship_generator.dart';
@@ -62,9 +63,15 @@ class ScipVisitor extends GeneralizingAstVisitor {
     if (node.declaredElement == null) return;
 
     final element = node.declaredElement!;
+
+    List<Relationship>? relationships;
+    if (Flags.instance.indexRelationships) {
+      relationships = relationshipsFor(node, element, _symbolGenerator);
+    }
+
     _registerAsDefinition(
       element,
-      relationships: relationshipsFor(node, element, _symbolGenerator),
+      relationships: relationships,
     );
   }
 


### PR DESCRIPTION
While support for indexing relationships was added, it was discovered that the results are not exactly accurate

This pr puts the functionality of indexing relationships behind a flag: `--index-relationships` to be worked on before its ready to be enabled by default