### PR TITLE
RM-203432 Release scip-dart 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.4
+
+- Put the generation of relationships field behind a `--index-relationships` flag which needs to be opted in. This was to continue to work on coverage of relationships support without effecting consumers.
+- Fixed issue where the `projectRoot` uri was being calculated incorrectly
+
 ## 1.1.3
 
 - generated scip bindings updated to provide relationship fields. This allows for "Go to Implementations" and other class/method inheritance navigation.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.1.3';
+const scipDartVersion = '1.1.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.1.3
+version: 1.1.4
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Fixed projectRoot URI calculation](https://github.com/Workiva/scip-dart/pull/70)
	* [Bump args from 2.4.1 to 2.4.2](https://github.com/Workiva/scip-dart/pull/71)
	* [Bump glob from 2.1.1 to 2.1.2](https://github.com/Workiva/scip-dart/pull/72)
	* [FEA-2357: Put relationship indexing behind a flag](https://github.com/Workiva/scip-dart/pull/77)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.1.3...Workiva:release_scip-dart_1.1.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.1.3...1.1.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=79)