### PR TITLE
FEA-2358 Release scip-dart 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.5
+
+- Fixed issues where cascade references would incorrectly index variables and assignments
+- Fixed issues where functions passed as parameters would incorrectly index their nested parameters
+
 ## 1.1.4
 
 - Put the generation of relationships field behind a `--index-relationships` flag which needs to be opted in. This was to continue to work on coverage of relationships support without effecting consumers.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.1.4';
+const scipDartVersion = '1.1.5';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.1.4
+version: 1.1.5
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump analyzer from 5.6.0 to 5.13.0](https://github.com/Workiva/scip-dart/pull/75)
	* [Bump args from 2.4.1 to 2.4.2](https://github.com/Workiva/scip-dart/pull/81)
	* [Bump glob from 2.1.1 to 2.1.2](https://github.com/Workiva/scip-dart/pull/83)
	* [FEA-2496: Fixed Cascade Indexing](https://github.com/Workiva/scip-dart/pull/84)
	* [FEA-2421: Fixed Functions as Parameters](https://github.com/Workiva/scip-dart/pull/88)
	* [Update dev dependencies for analyzer 2](https://github.com/Workiva/scip-dart/pull/90)
	* [Bump dart_dev from 4.0.1 to 4.0.2](https://github.com/Workiva/scip-dart/pull/95)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.1.4...Workiva:release_scip-dart_1.1.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.1.4...1.1.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=96)