### PR TITLE
FEA-2503 Release scip-dart 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.2.0
 
 - Added support for [occurrence diagnostics](https://github.com/sourcegraph/scip/blob/8d3634b4d6aa564129dac3ee462592ebc4203236/scip.proto#L579), all indexed packages will now include hints, warnings, and errors from the dart analysis server
-- Dependency updates
 
 ## 1.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Added support for [occurrence diagnostics](https://github.com/sourcegraph/scip/blob/8d3634b4d6aa564129dac3ee462592ebc4203236/scip.proto#L579), all indexed packages will now include hints, warnings, and errors from the dart analysis server
+- Dependency updates
+
 ## 1.1.5
 
 - Fixed issues where cascade references would incorrectly index variables and assignments
@@ -12,12 +17,12 @@
 
 ## 1.1.3
 
-- generated scip bindings updated to provide relationship fields. This allows for "Go to Implementations" and other class/method inheritance navigation.
+- Generated scip bindings updated to provide relationship fields. This allows for "Go to Implementations" and other class/method inheritance navigation.
 
 ## 1.1.2
 
-- added `--version` flag to retrieve the version of scip-dart
-- populated `ToolInfo.version` in resulting scip files
+- Added `--version` flag to retrieve the version of scip-dart
+- Populated `ToolInfo.version` in resulting scip files
 
 ## 1.1.1
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.1.5';
+const scipDartVersion = '1.2.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.1.5
+version: 1.2.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-2796: Occurrence Diagnostics](https://github.com/Workiva/scip-dart/pull/94)
	* [Bump dependency_validator from 3.2.2 to 3.2.3](https://github.com/Workiva/scip-dart/pull/97)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.1.5...Workiva:release_scip-dart_1.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.1.5...1.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=99)