### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dart_dev analyze
 
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dart_dev format --check
 
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dependency_validator

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,15 +20,15 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           # use a fixed version number so changes to 'stable', dont break snapshot diffs (language version is used in the scip symbol)
-          sdk: 2.18.7
-      - name: pub get scip-dart package
+          sdk: 2.19.6
+      - name: dart pub get scip-dart package
         run: dart pub get
 
-      - name: pub get basic-project directory
+      - name: dart pub get basic-project directory
         run: dart pub get
         working-directory: ./snapshots/input/basic-project
 
-      - name: pub get relationships-project directory
+      - name: dart pub get relationships-project directory
         run: dart pub get
         working-directory: ./snapshots/input/relationships-project
 
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
 
       # Setup repo to run on


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_219`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_219)