### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dart_dev analyze
 
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dart_dev format --check
 
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
       - run: dart run dependency_validator

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,15 +20,15 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           # use a fixed version number so changes to 'stable', dont break snapshot diffs (language version is used in the scip symbol)
-          sdk: 2.18.7
-      - name: pub get scip-dart package
+          sdk: 2.19.6
+      - name: dart pub get scip-dart package
         run: dart pub get
 
-      - name: pub get basic-project directory
+      - name: dart pub get basic-project directory
         run: dart pub get
         working-directory: ./snapshots/input/basic-project
 
-      - name: pub get relationships-project directory
+      - name: dart pub get relationships-project directory
         run: dart pub get
         working-directory: ./snapshots/input/relationships-project
 
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - run: dart pub get
 
       # Setup repo to run on

--- a/snapshots/output/basic-project/lib/main.dart
+++ b/snapshots/output/basic-project/lib/main.dart
@@ -6,11 +6,11 @@
   /// Takes a number
   /// Returns a number
   int fib(int n) {
-//^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //    ^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/fib().
 //    documentation ```dart
 //    documentation This is a fib function
-//        ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//        ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //            ^ definition local 0
 //            documentation ```dart
     if (n <= 1) return 0;
@@ -25,11 +25,11 @@
   void print_fib(int a) {
 //     ^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/print_fib().
 //     documentation ```dart
-//               ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//               ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //                   ^ definition local 1
 //                   documentation ```dart
     print(fib(a));
-//  ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //        ^^^ reference scip-dart pub dart_test 1.0.0 lib/main.dart/fib().
 //            ^ reference local 1
   }
@@ -38,7 +38,7 @@
 //      ^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/y.
 //      documentation ```dart
   String capture() {
-//^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //       ^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/capture().
 //       documentation ```dart
     return y;
@@ -63,7 +63,7 @@
 //           ^ definition local 3
 //           documentation ```dart
       print(i);
-//    ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //          ^ reference local 3
     }
   
@@ -99,7 +99,7 @@
 //     ^^^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/someFunction().
 //     documentation ```dart
 //     documentation Reference parameter: [value]
-//                  ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//                  ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //                      ^^^^^ definition local 5
 //                      documentation ```dart
     Foo(1);

--- a/snapshots/output/basic-project/lib/more.dart
+++ b/snapshots/output/basic-project/lib/more.dart
@@ -28,7 +28,7 @@
 //       ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/SleepMixin#sleep().
 //       documentation ```dart
       print('zzz...');
-//    ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
     }
   }
   
@@ -37,7 +37,7 @@
 //      documentation ```dart
 //                  ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/SleepMixin#
     String name;
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#name.
 //         documentation ```dart
     AnimalType type;
@@ -66,26 +66,26 @@
 //                      ^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/AnimalType#cat.
           soundMaker = () => print('Meow!');
 //        ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#soundMaker.
-//                           ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//                           ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
           break;
         case AnimalType.dog:
 //           ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/AnimalType#
 //                      ^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/AnimalType#dog.
           soundMaker = () => print('Woof!');
 //        ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#soundMaker.
-//                           ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//                           ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
           break;
         case AnimalType.bird:
 //           ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/AnimalType#
 //                      ^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/AnimalType#bird.
           soundMaker = () => print('Chirp!');
 //        ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#soundMaker.
-//                           ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//                           ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
           break;
         default:
           soundMaker = () => print('Unknown animal type');
 //        ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#soundMaker.
-//                           ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//                           ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
       }
     }
   
@@ -97,9 +97,9 @@
     }
   
     @override
-//   ^^^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/annotations.dart/override.
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/annotations.dart/override.
     String toString() {
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/Animal#toString().
 //         documentation ```dart
       return '$name the $type';
@@ -109,16 +109,16 @@
   }
   
   int calculateSum(List<int> numbers) {
-//^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //    ^^^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/calculateSum().
 //    documentation ```dart
-//                 ^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/list.dart/List#
-//                      ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//                 ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/list.dart/List#
+//                      ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //                           ^^^^^^^ definition local 1
 //                           documentation ```dart
     return numbers.reduce((value, element) => value + element);
 //         ^^^^^^^ reference local 1
-//                 ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/iterable.dart/Iterable#reduce().
+//                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/iterable.dart/Iterable#reduce().
 //                         ^^^^^ definition local 2
 //                         documentation ```dart
 //                                ^^^^^^^ definition local 3
@@ -131,12 +131,12 @@
 //     ^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/main().
 //     documentation ```dart
     List<int> numbers = [1, 2, 3, 4, 5];
-//  ^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/list.dart/List#
-//       ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//  ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/list.dart/List#
+//       ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //            ^^^^^^^ definition local 4
 //            documentation ```dart
     int sum = calculateSum(numbers);
-//  ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//  ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //      ^^^ definition local 5
 //      documentation ```dart
 //            ^^^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/calculateSum().
@@ -174,23 +174,23 @@
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/SleepMixin#sleep().
   
     print(cat);
-//  ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //        ^^^ reference local 6
     print(dog);
-//  ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //        ^^^ reference local 7
     print('The sum of $numbers is $sum');
-//  ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //                     ^^^^^^^ reference local 4
 //                                 ^^^ reference local 5
   
     print(math.Rectangle(1,2,3,4));
-//  ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //        ^^^^ reference scip-dart pub dart_test 1.0.0 lib/more.dart/math.
-//             ^^^^^^^^^ reference scip-dart pub dart:math 2.18.0 dart:math/rectangle.dart/Rectangle#
+//             ^^^^^^^^^ reference scip-dart pub dart:math 2.19.0 dart:math/rectangle.dart/Rectangle#
   
     [1,2].reduce((a, b) => a + b);
-//        ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/iterable.dart/Iterable#reduce().
+//        ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/iterable.dart/Iterable#reduce().
 //                ^ definition local 8
 //                documentation ```dart
 //                   ^ definition local 9
@@ -202,14 +202,14 @@
   void test(String Function(int) p) {}
 //     ^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/test().
 //     documentation ```dart
-//          ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
-//                          ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//          ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
+//                          ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //                               ^ definition local 10
 //                               documentation ```dart
   void deepTest(String Function(void Function(String test)) p) {}
 //     ^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/more.dart/deepTest().
 //     documentation ```dart
-//              ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
-//                                            ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//              ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
+//                                            ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //                                                          ^ definition local 11
 //                                                          documentation ```dart

--- a/snapshots/output/basic-project/lib/other.dart
+++ b/snapshots/output/basic-project/lib/other.dart
@@ -7,19 +7,19 @@
 //      ^^^ definition scip-dart pub dart_test 1.0.0 lib/other.dart/Foo#
 //      documentation ```dart
     int _far;
-//  ^^^ reference scip-dart pub dart:core 2.18.0 dart:core/int.dart/int#
+//  ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/int.dart/int#
 //      ^^^^ definition local 0
 //      documentation ```dart
     bool value;
-//  ^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/bool.dart/bool#
+//  ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/bool.dart/bool#
 //       ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/other.dart/Foo#value.
 //       documentation ```dart
     String value2;
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/other.dart/Foo#value2.
 //         documentation ```dart
     double value3;
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/double.dart/double#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/double.dart/double#
 //         ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/other.dart/Foo#value3.
 //         documentation ```dart
     Foo(this._far);
@@ -35,7 +35,7 @@
 //      ^^^ definition scip-dart pub dart_test 1.0.0 lib/other.dart/Bar#
 //      documentation ```dart
     String _someValue;
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^^^^^^^ definition local 2
 //         documentation ```dart
     Bar(this._someValue);
@@ -52,7 +52,7 @@
       _someValue = 'asdf';
 //    ^^^^^^^^^^ reference local 2
       print(_someValue);
-//    ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
 //          ^^^^^^^^^^ reference local 2
     }
   }
@@ -62,7 +62,7 @@
 //     documentation ```dart
     more.loadLibrary().then((_) => {
 //  ^^^^ reference scip-dart pub dart_test 1.0.0 lib/other.dart/more.
-//                     ^^^^ reference scip-dart pub dart:async 2.18.0 dart:async/future.dart/Future#then().
+//                     ^^^^ reference scip-dart pub dart:async 2.19.0 dart:async/future.dart/Future#then().
 //                           ^ definition local 4
 //                           documentation ```dart
       Bar('a').someMethod.call()

--- a/snapshots/output/relationships-project/lib/main.dart
+++ b/snapshots/output/relationships-project/lib/main.dart
@@ -3,7 +3,7 @@
 //               ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/Mammal#
 //               documentation ```dart
     String get hierarchy;
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //             ^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/Mammal#hierarchy.
 //             documentation ```dart
   }
@@ -14,7 +14,7 @@
 //               relationship scip-dart pub dart_test 1.0.0 lib/main.dart/Mammal# implementation
 //                              ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/main.dart/Mammal#
     String sound() => 'NOISE!';
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/Animal#sound().
 //         documentation ```dart
   }
@@ -25,7 +25,7 @@
     void execute() => print('swimming...');
 //       ^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/SwimAction#execute().
 //       documentation ```dart
-//                    ^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/print.dart/print().
+//                    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/print.dart/print().
   }
   
   class Dog extends Animal with SwimAction {
@@ -37,17 +37,17 @@
 //                  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/main.dart/Animal#
 //                              ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/main.dart/SwimAction#
     @override
-//   ^^^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/annotations.dart/override.
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/annotations.dart/override.
     String sound() => 'woof';
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/Dog#sound().
 //         documentation ```dart
 //         relationship scip-dart pub dart_test 1.0.0 lib/main.dart/Animal#sound(). implementation reference
   
     @override
-//   ^^^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/annotations.dart/override.
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/annotations.dart/override.
     String get hierarchy => 'dog.animal.mammal';
-//  ^^^^^^ reference scip-dart pub dart:core 2.18.0 dart:core/string.dart/String#
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/string.dart/String#
 //             ^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/main.dart/Dog#hierarchy.
 //             documentation ```dart
 //             relationship scip-dart pub dart_test 1.0.0 lib/main.dart/Mammal#hierarchy. implementation reference


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_2_19`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_2_19)