### PR TITLE
FEA-2798 Release scip-dart 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1
+- Fixed a bug discovered with diagnostic reporting, where most diagnostics were missing
+
 ## 1.2.0
 
 - Added support for [occurrence diagnostics](https://github.com/sourcegraph/scip/blob/8d3634b4d6aa564129dac3ee462592ebc4203236/scip.proto#L579), all indexed packages will now include hints, warnings, and errors from the dart analysis server

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.2.0';
+const scipDartVersion = '1.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.2.0
+version: 1.2.1
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Diagnostic bug fixes (and snapshot tests)](https://github.com/Workiva/scip-dart/pull/100)
	* [Dart 2.19](https://github.com/Workiva/scip-dart/pull/102)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.2.0...Workiva:release_scip-dart_1.2.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.2.0...1.2.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=103)