### PR TITLE
FEA-2871 Release scip-dart 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+- Default `index-relationships` to `true`, now all scip files will be generating relationship data by default
+- Fixed issue where `this.<param>` declared in a constructor (NormalFormalParameters), was incorrectly referencing the `this` part of the parameter
+- Updated the internal protobuf spec to the latest version. This includes populating `signatureDocumentation` as apart of symbol information declarations
+
 ## 1.2.1
 - Fixed a bug discovered with diagnostic reporting, where most diagnostics were missing
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.2.1';
+const scipDartVersion = '1.3.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.2.1
+version: 1.3.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Default index-relationships to true](https://github.com/Workiva/scip-dart/pull/104)
	* [Bump dart_dev from 4.0.2 to 4.1.0](https://github.com/Workiva/scip-dart/pull/105)
	* [Bump workiva_analysis_options from 1.3.0 to 1.4.1](https://github.com/Workiva/scip-dart/pull/107)
	* [added codeowners](https://github.com/Workiva/scip-dart/pull/108)
	* [FEA-3101: Added ast-printer dev tool](https://github.com/Workiva/scip-dart/pull/109)
	* [FEA-3206: Fix NormalFormalParameters](https://github.com/Workiva/scip-dart/pull/111)
	* [FEA-3236: Latest scip cli and diagnostic snapshot generation](https://github.com/Workiva/scip-dart/pull/112)
	* [FEA-3239: Updated scip Protobuf](https://github.com/Workiva/scip-dart/pull/114)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.2.1...Workiva:release_scip-dart_1.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.2.1...1.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=118)