### PR TITLE
FEA-3266 Release scip-dart 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+- Exported `SymbolGenerator` from the `symbol_generator.dart` entrypoint. Making use of this will allow generation of scip symbols outside of scip-darts main use case of indexing all the symbols in a dart repo
+
 ## 1.3.0
 - Default `index-relationships` to `true`, now all scip files will be generating relationship data by default
 - Fixed issue where `this.<param>` declared in a constructor (NormalFormalParameters), was incorrectly referencing the `this` part of the parameter

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.3.0';
+const scipDartVersion = '1.4.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.3.0
+version: 1.4.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-3404: export SymbolGenerator](https://github.com/Workiva/scip-dart/pull/122)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.3.0...Workiva:release_scip-dart_1.4.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.3.0...1.4.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=123)