### PR TITLE
FEDX-1213: Localized element selection logic to the SymbolGenerator

### DIFF
--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -156,7 +156,8 @@ class ScipVisitor extends GeneralizingAstVisitor {
     final symbol = _symbolGenerator.symbolFor(element);
     if (symbol == null) return null;
 
-    final meta = getSymbolMetadata(element, element.nameOffset, _analysisErrors);
+    final meta =
+        getSymbolMetadata(element, element.nameOffset, _analysisErrors);
     symbols.add(SymbolInformation(
       symbol: symbol,
       documentation: meta.documentation,

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -62,9 +62,8 @@ class ScipVisitor extends GeneralizingAstVisitor {
   }
 
   void _visitDeclaration(Declaration node) {
-    if (node.declaredElement == null) return;
-
-    final element = node.declaredElement!;
+    final element = _symbolGenerator.elementFor(node);
+    if (element == null) return;
 
     final relationships = relationshipsFor(node, element, _symbolGenerator);
 
@@ -76,21 +75,12 @@ class ScipVisitor extends GeneralizingAstVisitor {
   }
 
   void _visitNormalFormalParameter(NormalFormalParameter node) {
-    final element = node.declaredElement;
+    final element = _symbolGenerator.elementFor(node);
     if (element == null) return;
 
-    // if this parameter is a child of a GenericFunctionType (can be a
-    // typedef, or a function as a parameter), we don't want to index it
-    // as a definition (nothing is defined, just referenced). Return false
-    // and let the [_visitSimpleIdentifier] declare the reference
-    final parentParameter =
-        node.parent?.thisOrAncestorOfType<GenericFunctionType>();
-    if (parentParameter != null) return;
-
     if (node is FieldFormalParameter) {
-      final fieldElement = (element as FieldFormalParameterElement).field;
       _registerAsReference(
-        fieldElement!,
+        element,
         node,
         offset: node.name.offset,
         length: node.name.length,
@@ -102,39 +92,8 @@ class ScipVisitor extends GeneralizingAstVisitor {
   }
 
   void _visitSimpleIdentifier(SimpleIdentifier node) {
-    var element = node.staticElement;
-
-    // Both `.loadLibrary()`, and `.call()` are synthetic functions that
-    // have no definition. These should therefore should not be indexed.
-    if (element is FunctionElement && element.isSynthetic) {
-      if ([
-        FunctionElement.LOAD_LIBRARY_NAME,
-        FunctionElement.CALL_METHOD_NAME,
-      ].contains(element.name)) return;
-    }
-
-    // [element] for assignment fields is null. If the parent node
-    // is a `CompoundAssignmentExpression`, we know this node is referring
-    // to an assignment line. In that case, use the read/write element attached
-    // to this node instead of the [node]'s element
-    if (element == null) {
-      final assignmentExpr =
-          node.thisOrAncestorOfType<CompoundAssignmentExpression>();
-      if (assignmentExpr == null) return;
-
-      element = assignmentExpr.readElement ?? assignmentExpr.writeElement;
-    }
-
-    // When the identifier is a field, the analyzer creates synthetic getters/
-    // setters for it. We need to get the backing field.
-    if (element?.isSynthetic == true && element is PropertyAccessorElement) {
-      element = element.variable;
-    }
-
-    // element is null if there's nothing really to do for this node. Example: `void`
-    // TODO: One weird issue found: named parameters of external symbols were element.source
-    //       EX: `color(path, front: Styles.YELLOW);` where `color` comes from the chalk-dart package
-    if (element == null || element.source == null) return;
+    final element = _symbolGenerator.elementFor(node);
+    if (element == null) return;
 
     if (node.inDeclarationContext()) {
       _registerAsDefinition(element, node);
@@ -195,22 +154,21 @@ class ScipVisitor extends GeneralizingAstVisitor {
     List<Relationship>? relationships,
   }) {
     final symbol = _symbolGenerator.symbolFor(element);
-    if (symbol != null) {
-      final meta =
-          getSymbolMetadata(element, element.nameOffset, _analysisErrors);
-      symbols.add(SymbolInformation(
-        symbol: symbol,
-        documentation: meta.documentation,
-        relationships: relationships,
-        signatureDocumentation: meta.signatureDocumentation,
-      ));
+    if (symbol == null) return null;
 
-      occurrences.add(Occurrence(
-        range: _lineInfo.getRange(element.nameOffset, element.nameLength),
-        symbol: symbol,
-        symbolRoles: SymbolRole.Definition.value,
-        diagnostics: meta.diagnostics,
-      ));
-    }
+    final meta = getSymbolMetadata(element, element.nameOffset, _analysisErrors);
+    symbols.add(SymbolInformation(
+      symbol: symbol,
+      documentation: meta.documentation,
+      relationships: relationships,
+      signatureDocumentation: meta.signatureDocumentation,
+    ));
+
+    occurrences.add(Occurrence(
+      range: _lineInfo.getRange(element.nameOffset, element.nameLength),
+      symbol: symbol,
+      symbolRoles: SymbolRole.Definition.value,
+      diagnostics: meta.diagnostics,
+    ));
   }
 }

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -78,14 +78,16 @@ class ScipVisitor extends GeneralizingAstVisitor {
     final element = _symbolGenerator.elementFor(node);
     if (element == null) return;
 
+    // if the parameter is a `this.someFieldOnThClass`, we need to register
+    // it as a reference to said field, as well as a declaration of a parameter.
     if (node is FieldFormalParameter) {
+      final fieldElement = (element as FieldFormalParameterElement).field;
       _registerAsReference(
-        element,
+        fieldElement!,
         node,
         offset: node.name.offset,
         length: node.name.length,
       );
-      return;
     }
 
     _registerAsDefinition(element, node);

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -88,6 +88,11 @@ class ScipVisitor extends GeneralizingAstVisitor {
         offset: node.name.offset,
         length: node.name.length,
       );
+
+      // non-named parameters are considered 'local' symbols, and when combined
+      // with field formal parameters (this.foo), do not contain a declaration.
+      // if its not named, do not register it as a definition as well.
+      if (!node.isNamed) return;
     }
 
     _registerAsDefinition(element, node);

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -71,6 +71,12 @@ class SymbolGenerator {
       // When the identifier is a field, the analyzer creates synthetic getters/
       // setters for it. We need to get the backing field.
       if (element?.isSynthetic == true && element is PropertyAccessorElement) {
+        // The values field on enums is synthetic, and has no explicit definition like
+        // other fields do. Skip indexing for this case.
+        if (element.enclosingElement is EnumElement && element.name == 'values') {
+          return null;
+        }
+
         element = element.variable;
       }
 

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -29,12 +29,12 @@ class SymbolGenerator {
     if (node is Declaration) {
       return node.declaredElement;
     } else if (node is NormalFormalParameter) {
-
       // if this parameter is a child of a GenericFunctionType (can be a
       // typedef, or a function as a parameter), we don't want to index it
       // as a definition (nothing is defined, just referenced). Return false
       // and let the [_visitSimpleIdentifier] declare the reference
-      final parentParameter = node.parent?.thisOrAncestorOfType<GenericFunctionType>();
+      final parentParameter =
+          node.parent?.thisOrAncestorOfType<GenericFunctionType>();
       if (parentParameter != null) return null;
 
       var element = node.declaredElement;
@@ -77,18 +77,16 @@ class SymbolGenerator {
       // element is null if there's nothing really to do for this node. Example: `void`
       // TODO: One weird issue found: named parameters of external symbols were element.source
       //       EX: `color(path, front: Styles.YELLOW);` where `color` comes from the chalk-dart package
-      if (element == null || element.source == null) return null;
+      if (element?.source == null) return null;
 
-    return node.staticElement;
+      return element;
+    }
+
+    display('WARN: Received unknown ast node type in elementFor: '
+        '${node.runtimeType} ($node). Skipping');
+
+    return null;
   }
-
-  display(
-    'WARN: Received unknown ast node type in elementFor: '
-    '${node.runtimeType} ($node). Skipping'
-  );
-
-  return null;
-}
 
   /// For a given `Element` returns the scip symbol form.
   ///
@@ -305,5 +303,3 @@ class SymbolGenerator {
     }
   }
 }
-
-

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -40,9 +40,6 @@ class SymbolGenerator {
       var element = node.declaredElement;
       if (element == null) return null;
 
-      if (node is FieldFormalParameter) {
-        return (element as FieldFormalParameterElement).field;
-      }
       return element;
     } else if (node is SimpleIdentifier) {
       var element = node.staticElement;
@@ -73,8 +70,7 @@ class SymbolGenerator {
       if (element?.isSynthetic == true && element is PropertyAccessorElement) {
         // The values field on enums is synthetic, and has no explicit definition like
         // other fields do. Skip indexing for this case.
-        if (element.enclosingElement is EnumElement &&
-            element.name == 'values') {
+        if (element.enclosingElement is EnumElement && element.name == 'values') {
           return null;
         }
 

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -73,7 +73,8 @@ class SymbolGenerator {
       if (element?.isSynthetic == true && element is PropertyAccessorElement) {
         // The values field on enums is synthetic, and has no explicit definition like
         // other fields do. Skip indexing for this case.
-        if (element.enclosingElement is EnumElement && element.name == 'values') {
+        if (element.enclosingElement is EnumElement &&
+            element.name == 'values') {
           return null;
         }
 

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -70,7 +70,8 @@ class SymbolGenerator {
       if (element?.isSynthetic == true && element is PropertyAccessorElement) {
         // The values field on enums is synthetic, and has no explicit definition like
         // other fields do. Skip indexing for this case.
-        if (element.enclosingElement is EnumElement && element.name == 'values') {
+        if (element.enclosingElement is EnumElement &&
+            element.name == 'values') {
           return null;
         }
 

--- a/snapshots/input/basic-project/lib/more.dart
+++ b/snapshots/input/basic-project/lib/more.dart
@@ -20,6 +20,7 @@ class Animal with SleepMixin {
   SoundMaker? soundMaker;
 
   Animal(this.name, {required this.type}) {
+    print(AnimalType.values);
     switch (type) {
       case AnimalType.cat:
         soundMaker = () => print('Meow!');

--- a/snapshots/output/basic-project/lib/more.dart
+++ b/snapshots/output/basic-project/lib/more.dart
@@ -42,7 +42,6 @@
 //  ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //              ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#name.
-//              ^^^^ definition local 0
 //                                   ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#type.
 //                                   ^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
       print(AnimalType.values);
@@ -101,14 +100,14 @@
 //    ^^^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/calculateSum().
 //                 ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`list.dart`/List#
 //                      ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//                           ^^^^^^^ definition local 1
+//                           ^^^^^^^ definition local 0
     return numbers.reduce((value, element) => value + element);
-//         ^^^^^^^ reference local 1
+//         ^^^^^^^ reference local 0
 //                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`iterable.dart`/Iterable#reduce().
-//                         ^^^^^ definition local 2
-//                                ^^^^^^^ definition local 3
-//                                            ^^^^^ reference local 2
-//                                                    ^^^^^^^ reference local 3
+//                         ^^^^^ definition local 1
+//                                ^^^^^^^ definition local 2
+//                                            ^^^^^ reference local 1
+//                                                    ^^^^^^^ reference local 2
   }
   
   void main() {
@@ -116,52 +115,52 @@
     List<int> numbers = [1, 2, 3, 4, 5];
 //  ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`list.dart`/List#
 //       ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//            ^^^^^^^ definition local 4
+//            ^^^^^^^ definition local 3
     int sum = calculateSum(numbers);
 //  ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//      ^^^ definition local 5
+//      ^^^ definition local 4
 //            ^^^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/calculateSum().
-//                         ^^^^^^^ reference local 4
+//                         ^^^^^^^ reference local 3
   
     Animal cat = Animal('Kitty', type: AnimalType.cat);
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
-//         ^^^ definition local 6
+//         ^^^ definition local 5
 //               ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //                               ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
 //                                     ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
 //                                                ^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#cat.
     Animal dog = Animal('Buddy', type: AnimalType.dog);
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
-//         ^^^ definition local 7
+//         ^^^ definition local 6
 //               ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //                               ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
 //                                     ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
 //                                                ^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#dog.
   
     cat.makeSound();
-//  ^^^ reference local 6
+//  ^^^ reference local 5
 //      ^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#makeSound().
     cat.sleep();
-//  ^^^ reference local 6
+//  ^^^ reference local 5
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/SleepMixin#sleep().
   
     dog.makeSound();
-//  ^^^ reference local 7
+//  ^^^ reference local 6
 //      ^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#makeSound().
     dog.sleep();
-//  ^^^ reference local 7
+//  ^^^ reference local 6
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/SleepMixin#sleep().
   
     print(cat);
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//        ^^^ reference local 6
+//        ^^^ reference local 5
     print(dog);
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//        ^^^ reference local 7
+//        ^^^ reference local 6
     print('The sum of $numbers is $sum');
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//                     ^^^^^^^ reference local 4
-//                                 ^^^ reference local 5
+//                     ^^^^^^^ reference local 3
+//                                 ^^^ reference local 4
   
     print(math.Rectangle(1,2,3,4));
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
@@ -170,19 +169,19 @@
   
     [1,2].reduce((a, b) => a + b);
 //        ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`iterable.dart`/Iterable#reduce().
-//                ^ definition local 8
-//                   ^ definition local 9
-//                         ^ reference local 8
-//                             ^ reference local 9
+//                ^ definition local 7
+//                   ^ definition local 8
+//                         ^ reference local 7
+//                             ^ reference local 8
   }
   
   void test(String Function(int) p) {}
 //     ^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/test().
 //          ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //                          ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//                               ^ definition local 10
+//                               ^ definition local 9
   void deepTest(String Function(void Function(String test)) p) {}
 //     ^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/deepTest().
 //              ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //                                            ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//                                                          ^ definition local 11
+//                                                          ^ definition local 10

--- a/snapshots/output/basic-project/lib/more.dart
+++ b/snapshots/output/basic-project/lib/more.dart
@@ -42,7 +42,9 @@
 //  ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //              ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#name.
+//              ^^^^ definition local 0
 //                                   ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#type.
+//                                   ^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
       print(AnimalType.values);
 //    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
 //          ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
@@ -99,14 +101,14 @@
 //    ^^^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/calculateSum().
 //                 ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`list.dart`/List#
 //                      ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//                           ^^^^^^^ definition local 0
+//                           ^^^^^^^ definition local 1
     return numbers.reduce((value, element) => value + element);
-//         ^^^^^^^ reference local 0
+//         ^^^^^^^ reference local 1
 //                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`iterable.dart`/Iterable#reduce().
-//                         ^^^^^ definition local 1
-//                                ^^^^^^^ definition local 2
-//                                            ^^^^^ reference local 1
-//                                                    ^^^^^^^ reference local 2
+//                         ^^^^^ definition local 2
+//                                ^^^^^^^ definition local 3
+//                                            ^^^^^ reference local 2
+//                                                    ^^^^^^^ reference local 3
   }
   
   void main() {
@@ -114,52 +116,52 @@
     List<int> numbers = [1, 2, 3, 4, 5];
 //  ^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`list.dart`/List#
 //       ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//            ^^^^^^^ definition local 3
+//            ^^^^^^^ definition local 4
     int sum = calculateSum(numbers);
 //  ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//      ^^^ definition local 4
+//      ^^^ definition local 5
 //            ^^^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/calculateSum().
-//                         ^^^^^^^ reference local 3
+//                         ^^^^^^^ reference local 4
   
     Animal cat = Animal('Kitty', type: AnimalType.cat);
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
-//         ^^^ definition local 5
+//         ^^^ definition local 6
 //               ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //                               ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
 //                                     ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
 //                                                ^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#cat.
     Animal dog = Animal('Buddy', type: AnimalType.dog);
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
-//         ^^^ definition local 6
+//         ^^^ definition local 7
 //               ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //                               ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#`<constructor>`().(type)
 //                                     ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
 //                                                ^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#dog.
   
     cat.makeSound();
-//  ^^^ reference local 5
+//  ^^^ reference local 6
 //      ^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#makeSound().
     cat.sleep();
-//  ^^^ reference local 5
+//  ^^^ reference local 6
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/SleepMixin#sleep().
   
     dog.makeSound();
-//  ^^^ reference local 6
+//  ^^^ reference local 7
 //      ^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#makeSound().
     dog.sleep();
-//  ^^^ reference local 6
+//  ^^^ reference local 7
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/SleepMixin#sleep().
   
     print(cat);
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//        ^^^ reference local 5
+//        ^^^ reference local 6
     print(dog);
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//        ^^^ reference local 6
+//        ^^^ reference local 7
     print('The sum of $numbers is $sum');
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//                     ^^^^^^^ reference local 3
-//                                 ^^^ reference local 4
+//                     ^^^^^^^ reference local 4
+//                                 ^^^ reference local 5
   
     print(math.Rectangle(1,2,3,4));
 //  ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
@@ -168,19 +170,19 @@
   
     [1,2].reduce((a, b) => a + b);
 //        ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`iterable.dart`/Iterable#reduce().
-//                ^ definition local 7
-//                   ^ definition local 8
-//                         ^ reference local 7
-//                             ^ reference local 8
+//                ^ definition local 8
+//                   ^ definition local 9
+//                         ^ reference local 8
+//                             ^ reference local 9
   }
   
   void test(String Function(int) p) {}
 //     ^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/test().
 //          ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //                          ^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#
-//                               ^ definition local 9
+//                               ^ definition local 10
   void deepTest(String Function(void Function(String test)) p) {}
 //     ^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`more.dart`/deepTest().
 //              ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //                                            ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//                                                          ^ definition local 10
+//                                                          ^ definition local 11

--- a/snapshots/output/basic-project/lib/more.dart
+++ b/snapshots/output/basic-project/lib/more.dart
@@ -43,6 +43,9 @@
 //  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#
 //              ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#name.
 //                                   ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#type.
+      print(AnimalType.values);
+//    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
+//          ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/AnimalType#
       switch (type) {
 //            ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/Animal#type.
         case AnimalType.cat:

--- a/snapshots/output/basic-project/lib/other.dart
+++ b/snapshots/output/basic-project/lib/other.dart
@@ -21,12 +21,16 @@
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#
       this._far, {
 //         ^^^^ reference local 0
+//         ^^^^ definition local 1
       required this.value,
 //                  ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
+//                  ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value)
       required this.value2,
 //                  ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value2.
+//                  ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value2)
       this.value3,
 //         ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value3.
+//         ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value3)
     }) {
       print(_far);
 //    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
@@ -38,19 +42,20 @@
 //      ^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
     String _someValue;
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//         ^^^^^^^^^^ definition local 1
+//         ^^^^^^^^^^ definition local 2
     Bar(this._someValue);
 //  ^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#`<constructor>`().
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
-//           ^^^^^^^^^^ reference local 1
+//           ^^^^^^^^^^ reference local 2
+//           ^^^^^^^^^^ definition local 3
   
     void someMethod() {
 //       ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#someMethod().
       _someValue = 'asdf';
-//    ^^^^^^^^^^ reference local 1
+//    ^^^^^^^^^^ reference local 2
       print(_someValue);
 //    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//          ^^^^^^^^^^ reference local 1
+//          ^^^^^^^^^^ reference local 2
     }
   }
   
@@ -59,7 +64,7 @@
     more.loadLibrary().then((_) => {
 //  ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/more.
 //                     ^^^^ reference scip-dart pub dart:async 2.19.0 dart:async/`future.dart`/Future#then().
-//                           ^ definition local 2
+//                           ^ definition local 4
       Bar('a').someMethod.call()
 //    ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
 //             ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#someMethod().
@@ -72,7 +77,7 @@
 //                                       ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
   
     final someStr = 'someStr';
-//        ^^^^^^^ definition local 3
+//        ^^^^^^^ definition local 5
     Foo(2, value: false, value2: 'some Val!')
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#
 //         ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value)
@@ -81,12 +86,12 @@
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
       ..value2 = someStr
 //      ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value2.
-//               ^^^^^^^ reference local 3
+//               ^^^^^^^ reference local 5
       ..value3 = 2.15;
 //      ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value3.
   
     more.test((_) => 'val');
 //  ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/more.
 //       ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/test().
-//             ^ definition local 4
+//             ^ definition local 6
   }

--- a/snapshots/output/basic-project/lib/other.dart
+++ b/snapshots/output/basic-project/lib/other.dart
@@ -21,7 +21,6 @@
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#
       this._far, {
 //         ^^^^ reference local 0
-//         ^^^^ definition local 1
       required this.value,
 //                  ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
 //                  ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value)
@@ -42,20 +41,19 @@
 //      ^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
     String _someValue;
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//         ^^^^^^^^^^ definition local 2
+//         ^^^^^^^^^^ definition local 1
     Bar(this._someValue);
 //  ^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#`<constructor>`().
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
-//           ^^^^^^^^^^ reference local 2
-//           ^^^^^^^^^^ definition local 3
+//           ^^^^^^^^^^ reference local 1
   
     void someMethod() {
 //       ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#someMethod().
       _someValue = 'asdf';
-//    ^^^^^^^^^^ reference local 2
+//    ^^^^^^^^^^ reference local 1
       print(_someValue);
 //    ^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`print.dart`/print().
-//          ^^^^^^^^^^ reference local 2
+//          ^^^^^^^^^^ reference local 1
     }
   }
   
@@ -64,7 +62,7 @@
     more.loadLibrary().then((_) => {
 //  ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/more.
 //                     ^^^^ reference scip-dart pub dart:async 2.19.0 dart:async/`future.dart`/Future#then().
-//                           ^ definition local 4
+//                           ^ definition local 2
       Bar('a').someMethod.call()
 //    ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#
 //             ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Bar#someMethod().
@@ -77,7 +75,7 @@
 //                                       ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
   
     final someStr = 'someStr';
-//        ^^^^^^^ definition local 5
+//        ^^^^^^^ definition local 3
     Foo(2, value: false, value2: 'some Val!')
 //  ^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#
 //         ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#`<constructor>`().(value)
@@ -86,12 +84,12 @@
 //      ^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value.
       ..value2 = someStr
 //      ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value2.
-//               ^^^^^^^ reference local 5
+//               ^^^^^^^ reference local 3
       ..value3 = 2.15;
 //      ^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/Foo#value3.
   
     more.test((_) => 'val');
 //  ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`other.dart`/more.
 //       ^^^^ reference scip-dart pub dart_test 1.0.0 lib/`more.dart`/test().
-//             ^ definition local 6
+//             ^ definition local 4
   }


### PR DESCRIPTION
There are 2 parts to getting a symbol representation of a dart reference/definition: selecting the correct `Element` based on a provided `AstNode`, and building the string using that selected element

Before this PR, the element selection part was done directly within the scip_visitor, which is not exported from scip-dart. This PR moves all of this logic to the symbol_generator, which _is_ exported and available

The SymbolGenerator was selected as the `elementFor` method is a necessary step in symbol generation. It seemed like a fitting, and convenient place (due to the pre-existing exporting of the class)

Also, unrelated, but closes #37 and closes #120