### PR TITLE
FEA-3407 Release scip-dart 1.4.1

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.4.0';
+const scipDartVersion = '1.4.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.4.0
+version: 1.4.1
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [SBOM from GHA - again](https://github.com/Workiva/scip-dart/pull/125)
	* [Bump dependency_validator from 3.2.3 to 4.0.0](https://github.com/Workiva/scip-dart/pull/126)
	* [Bump dependency_validator from 4.0.0 to 4.1.0](https://github.com/Workiva/scip-dart/pull/127)
	* [FEDX-1213: Localized element selection logic to the SymbolGenerator](https://github.com/Workiva/scip-dart/pull/128)
	* [Updated Changelog for 1.4.1](https://github.com/Workiva/scip-dart/pull/130)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.4.0...Workiva:release_scip-dart_1.4.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.4.0...1.4.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=131)