### PR TITLE
FEDX-1388: Implement gha-dart-oss

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,8 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6
-      - run: dart pub get
+      - working-directory: ${{ matrix.consumer.packagePath || './' }}
+        run: dart pub get
 
       # Setup repo to run on
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
         consumer: [
           { repo: "Workiva/over_react" },
           { repo: "Workiva/w_module" },
-          { repo: "rrousselGit/provider", packagePath: "/provider/packages/provider" },
+          { repo: "rrousselGit/provider", packagePath: "/packages/provider" },
           { repo: "dart-lang/args", ref: "v2.4.2" } # master requires dart 3
         ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,11 +73,12 @@ jobs:
   consumer:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         consumer: [
-          { repo: "Workiva/over_react", ref: "master"},
-          { repo: "Workiva/w_module", ref: "master"},
-          { repo: "rrousselGit/provider", ref: "master"},
+          { repo: "Workiva/over_react" },
+          { repo: "Workiva/w_module" },
+          { repo: "rrousselGit/provider", packagePath: "/provider/packages/provider" },
           { repo: "dart-lang/args", ref: "v2.4.2" } # master requires dart 3
         ]
 
@@ -93,10 +94,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ matrix.consumer.repo }}
-          path: ${{ matrix.consumer.repo }}
-          ref: ${{ matrix.consumer.ref }}
+          path: ${{ matrix.consumer.repo}}
+          ref: ${{ matrix.consumer.ref || 'master' }}
       - run: dart pub get
         working-directory: ${{ matrix.consumer.repo }}
 
       - run: |
-          dart run scip_dart ./${{ matrix.consumer.repo }} || exit 1
+          dart run scip_dart ./${{ matrix.consumer.repo }}${{ matrix.consumer.packagePath || '' }} || exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: [
-          "Workiva/over_react",
-          "Workiva/w_module",
-          "rrousselGit/provider",
-          "dart-lang/args",
+        consumer: [
+          { repo: "Workiva/over_react", ref: "master"},
+          { repo: "Workiva/w_module", ref: "master"},
+          { repo: "rrousselGit/provider", ref: "master"},
+          { repo: "dart-lang/args", ref: "v2.4.2" } # master requires dart 3
         ]
 
     steps:
@@ -92,10 +92,11 @@ jobs:
       # Setup repo to run on
       - uses: actions/checkout@v4
         with:
-          repository: ${{ matrix.repo }}
-          path: ${{ matrix.repo }}
+          repository: ${{ matrix.consumer.repo }}
+          path: ${{ matrix.consumer.repo }}
+          ref: ${{ matrix.consumer.ref }}
       - run: dart pub get
-        working-directory: ${{ matrix.repo }}
+        working-directory: ${{ matrix.consumer.repo }}
 
       - run: |
-          dart run scip_dart ./${{ matrix.repo }} || exit 1
+          dart run scip_dart ./${{ matrix.consumer.repo }} || exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6
-      - working-directory: ${{ matrix.consumer.packagePath || './' }}
-        run: dart pub get
+      - run: dart pub get
 
       # Setup repo to run on
       - uses: actions/checkout@v4
@@ -98,7 +97,7 @@ jobs:
           path: ${{ matrix.consumer.repo}}
           ref: ${{ matrix.consumer.ref || 'master' }}
       - run: dart pub get
-        working-directory: ${{ matrix.consumer.repo }}
+        working-directory: ${{ matrix.consumer.repo }}${{ matrix.consumer.packagePath || '' }}
 
       - run: |
           dart run scip_dart ./${{ matrix.consumer.repo }}${{ matrix.consumer.packagePath || '' }} || exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,6 @@ jobs:
         consumer: [
           { repo: "Workiva/over_react" },
           { repo: "Workiva/w_module" },
-          { repo: "rrousselGit/provider", packagePath: "/packages/provider" },
           { repo: "dart-lang/args", ref: "v2.4.2" } # master requires dart 3
         ]
 
@@ -97,7 +96,7 @@ jobs:
           path: ${{ matrix.consumer.repo}}
           ref: ${{ matrix.consumer.ref || 'master' }}
       - run: dart pub get
-        working-directory: ${{ matrix.consumer.repo }}${{ matrix.consumer.packagePath || '' }}
+        working-directory: ${{ matrix.consumer.repo }}
 
       - run: |
-          dart run scip_dart ./${{ matrix.consumer.repo }}${{ matrix.consumer.packagePath || '' }} || exit 1
+          dart run scip_dart ./${{ matrix.consumer.repo }} || exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,26 +13,16 @@ permissions:
 
 jobs:
   checks:
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.0
+
+  sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 2.19.6
-
-      - run: dart pub get
-
-      - name: Analyze
-        run: dart run dart_dev analyze
-
-      - name: Format
-        run: dart run dart_dev format --check
-
-      - name: Validate Dependencies
-        run: dart run dependency_validator
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@v0
         with:
           path: ./
           format: cyclonedx-json
@@ -40,7 +30,7 @@ jobs:
   snapshots:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install scip cli
         run: |
           bash -c 'curl -L "https://github.com/sourcegraph/scip/releases/download/v0.3.3/scip-linux-amd64.tar.gz"' | tar xzf - scip
@@ -100,9 +90,9 @@ jobs:
       - run: dart pub get
 
       # Setup repo to run on
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          repo: ${{ matrix.repo }}
+          repository: ${{ matrix.repo }}
           path: ${{ matrix.repo }}
       - run: dart pub get
         working-directory: ${{ matrix.repo }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,16 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  # Generates and uploads sbom, and publishes to pub.dev
+  publish:
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.0


### PR DESCRIPTION
We now have [Workiva/gha-dart-oss](https://github.com/Workiva/gha-dart-oss) to establish the boilerplate of some of the github actions in oss repos

Updated this repo to rely on this, which includes auto-publishing to pub.dev