### PR TITLE
FEDX-1401: Added dependentabot for gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: pub
     versioning-strategy: increase
     directory: /

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.0
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.1
 
   sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,4 +13,4 @@ permissions:
 jobs:
   # Generates and uploads sbom, and publishes to pub.dev
   publish:
-    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.0
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.1


### PR DESCRIPTION
# [FEDX-1401](https://jira.atl.workiva.net/browse/FEDX-1401)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1401)

We want to monitor gha dependencies and keep them up to date

This change will also test: https://github.com/Workiva/gha-dart-oss/pull/13