### PR TITLE
FEDX-1391 Release scip-dart 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3
+- Updated the min dart version to `>=2.19 <3.0.0`, this is a pre-step to supporting dart 3
+
+## 1.4.2
+- Minor dependency updates and a test release for auto-tagging
+
 ## 1.4.1
 - Added `elementFor` to the exported `SymbolGenerator` that can be used to retrieve the analyzer `Element` that should be used when generating symbols
 - Fixed issue where the synthetic `values` field on `Enum` types was getting indexed (we just dont want to index this)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.4.2';
+const scipDartVersion = '1.4.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.4.2
+version: 1.4.3
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* [FEDX-1401: Added dependentabot for gha](https://github.com/Workiva/scip-dart/pull/134)
* [Bump actions/checkout from 3 to 4](https://github.com/Workiva/scip-dart/pull/135)
* [FEDX-1453: dart 2.19 min](https://github.com/Workiva/scip-dart/pull/138)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.4.2...Workiva:release_scip-dart_1.4.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.4.2...1.4.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=136)