### PR TITLE
Added Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM dart:3.1.2 as builder
+
+COPY . /sources
+WORKDIR /sources
+RUN dart compile exe -o scip_dart ./bin/scip_dart.dart
+
+CMD ["scip_dart"]


### PR DESCRIPTION
In order for scip-dart to run as an auto-indexer, we need to provide a Dockerfile that can be ran from the lua script. More information about this can be found [here](https://sourcegraph.com/docs/code-search/code-navigation/inference_configuration)

Adding this dockerfile here, TBD on how best to publish this for consumption (ideally dockerhub... but 🤷 )