### PR TITLE
FEDX-1453: dart 2.19 min

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 executables:
   scip_dart:
 
 dependencies:
-  analyzer: ^5.4.0
+  analyzer: ^5.13.0
   args: ^2.4.0
   package_config: ^2.1.0
   path: ^1.8.3


### PR DESCRIPTION
# [FEDX-1453](https://jira.atl.workiva.net/browse/FEDX-1453)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1453)

There's not really a good reason that we're supporting a lower bound of dart `2.18`, bumping the project to a lower bound of `2.19`, so we can implement the most up to date [analyzer](https://pub.dev/packages/analyzer/versions) version that still supports dart 2

There's active work to figure out the best way of supporting both dart 2 and 3, this is somewhat of a precursor to that work