### PR TITLE
FEDX-1455 Release scip-dart 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.4
+- Minor update to release CI
+
 ## 1.4.3
 - Updated the min dart version to `>=2.19 <3.0.0`, this is a pre-step to supporting dart 3
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.4.3';
+const scipDartVersion = '1.4.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.4.3
+version: 1.4.4
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump Workiva/gha-dart-oss from 0.1.1 to 0.1.2](https://github.com/Workiva/scip-dart/pull/139)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.4.3...Workiva:release_scip-dart_1.4.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.4.3...1.4.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=140)