### PR TITLE
FEDX-1648: Added symbol kind support

### DIFF
--- a/lib/src/kind_generator.dart
+++ b/lib/src/kind_generator.dart
@@ -1,0 +1,26 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:scip_dart/src/gen/scip.pbenum.dart';
+
+SymbolInformation_Kind symbolKindFor(Element element) {
+  // These mappings are declared in the same order as their symbol parsing
+  // counterpart is declared within SymbolGenerator._getDescriptor. Ensure
+  // this order stays consistent to ensure the correct kinds are included.
+  final mappings = {
+    ClassElement: SymbolInformation_Kind.Class,
+    // MixinElement: SymbolInformation_Kind.Mixin, // Pending: https://github.com/sourcegraph/scip/pull/277
+    EnumElement: SymbolInformation_Kind.Enum,
+    TypeAliasElement: SymbolInformation_Kind.TypeAlias,
+    // ExtensionDeclaration: SymbolInformation_Kind.Extension, // Pending: https://github.com/sourcegraph/scip/pull/277
+    ConstructorElement: SymbolInformation_Kind.Constructor,
+    MethodElement: SymbolInformation_Kind.Method,
+    FunctionElement: SymbolInformation_Kind.Function,
+    TopLevelVariableElement: SymbolInformation_Kind.Variable,
+    PrefixElement: SymbolInformation_Kind.Namespace, // unsure if this is the right call for this
+    TypeParameterElement: SymbolInformation_Kind.TypeParameter,
+    ParameterElement: SymbolInformation_Kind.Parameter,
+    PropertyAccessorElement: SymbolInformation_Kind.Property,
+    FieldElement: SymbolInformation_Kind.Field,
+  };
+
+  return mappings[element.runtimeType] ?? SymbolInformation_Kind.UnspecifiedKind;
+}

--- a/lib/src/kind_generator.dart
+++ b/lib/src/kind_generator.dart
@@ -15,8 +15,7 @@ SymbolInformation_Kind symbolKindFor(Element element) {
     MethodElement: SymbolInformation_Kind.Method,
     FunctionElement: SymbolInformation_Kind.Function,
     TopLevelVariableElement: SymbolInformation_Kind.Variable,
-    PrefixElement: SymbolInformation_Kind
-        .Namespace, // unsure if this is the right call for this
+    PrefixElement: SymbolInformation_Kind.Namespace,
     TypeParameterElement: SymbolInformation_Kind.TypeParameter,
     ParameterElement: SymbolInformation_Kind.Parameter,
     PropertyAccessorElement: SymbolInformation_Kind.Property,

--- a/lib/src/kind_generator.dart
+++ b/lib/src/kind_generator.dart
@@ -15,12 +15,14 @@ SymbolInformation_Kind symbolKindFor(Element element) {
     MethodElement: SymbolInformation_Kind.Method,
     FunctionElement: SymbolInformation_Kind.Function,
     TopLevelVariableElement: SymbolInformation_Kind.Variable,
-    PrefixElement: SymbolInformation_Kind.Namespace, // unsure if this is the right call for this
+    PrefixElement: SymbolInformation_Kind
+        .Namespace, // unsure if this is the right call for this
     TypeParameterElement: SymbolInformation_Kind.TypeParameter,
     ParameterElement: SymbolInformation_Kind.Parameter,
     PropertyAccessorElement: SymbolInformation_Kind.Property,
     FieldElement: SymbolInformation_Kind.Field,
   };
 
-  return mappings[element.runtimeType] ?? SymbolInformation_Kind.UnspecifiedKind;
+  return mappings[element.runtimeType] ??
+      SymbolInformation_Kind.UnspecifiedKind;
 }

--- a/lib/src/kind_generator.dart
+++ b/lib/src/kind_generator.dart
@@ -1,27 +1,46 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:scip_dart/src/gen/scip.pbenum.dart';
 
-SymbolInformation_Kind symbolKindFor(Element element) {
+SymbolInformation_Kind symbolKindFor(Element el) {
   // These mappings are declared in the same order as their symbol parsing
   // counterpart is declared within SymbolGenerator._getDescriptor. Ensure
   // this order stays consistent to ensure the correct kinds are included.
-  final mappings = {
-    ClassElement: SymbolInformation_Kind.Class,
-    // MixinElement: SymbolInformation_Kind.Mixin, // Pending: https://github.com/sourcegraph/scip/pull/277
-    EnumElement: SymbolInformation_Kind.Enum,
-    TypeAliasElement: SymbolInformation_Kind.TypeAlias,
-    // ExtensionDeclaration: SymbolInformation_Kind.Extension, // Pending: https://github.com/sourcegraph/scip/pull/277
-    ConstructorElement: SymbolInformation_Kind.Constructor,
-    MethodElement: SymbolInformation_Kind.Method,
-    FunctionElement: SymbolInformation_Kind.Function,
-    TopLevelVariableElement: SymbolInformation_Kind.Variable,
-    PrefixElement: SymbolInformation_Kind.Namespace,
-    TypeParameterElement: SymbolInformation_Kind.TypeParameter,
-    ParameterElement: SymbolInformation_Kind.Parameter,
-    PropertyAccessorElement: SymbolInformation_Kind.Property,
-    FieldElement: SymbolInformation_Kind.Field,
-  };
+  //
+  // Note, we cannot declare this dynamically via a lookup map since the actual
+  // type of [el], is the Impl counterpart (`ClassElementImpl`). runtimeType
+  // type checking _does not_ take inheritance into account and `is` cannot
+  // be used with variables. Hence the large list of if statements.
+  if (el is ClassElement) {
+    return SymbolInformation_Kind.Class;
+  } else if (el is MixinElement) {
+    // Pending: https://github.com/sourcegraph/scip/pull/277
+    // return SymbolInformation_Kind.Mixin;
+  } else if (el is EnumElement) {
+    return SymbolInformation_Kind.Enum;
+  } else if (el is TypeAliasElement) {
+    return SymbolInformation_Kind.TypeAlias;
+  } else if (el is ExtensionElement) {
+    // Pending: https://github.com/sourcegraph/scip/pull/277
+    // return SymbolInformation_Kind.Extension;
+  } else if (el is ConstructorElement) {
+    return SymbolInformation_Kind.Constructor;
+  } else if (el is MethodElement) {
+    return SymbolInformation_Kind.Method;
+  } else if (el is FunctionElement) {
+    return SymbolInformation_Kind.Function;
+  } else if (el is TopLevelVariableElement) {
+    return SymbolInformation_Kind.Variable;
+  } else if (el is PrefixElement) {
+    return SymbolInformation_Kind.Namespace;
+  } else if (el is TypeParameterElement) {
+    return SymbolInformation_Kind.TypeParameter;
+  } else if (el is ParameterElement) {
+    return SymbolInformation_Kind.Parameter;
+  } else if (el is PropertyAccessorElement) {
+    return SymbolInformation_Kind.Property;
+  } else if (el is FieldElement) {
+    return SymbolInformation_Kind.Field;
+  }
 
-  return mappings[element.runtimeType] ??
-      SymbolInformation_Kind.UnspecifiedKind;
+  return SymbolInformation_Kind.UnspecifiedKind;
 }

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -143,11 +143,10 @@ class ScipVisitor extends GeneralizingAstVisitor {
         )) {
           final meta = getSymbolMetadata(element, offset, _analysisErrors);
           globalExternalSymbols.add(SymbolInformation(
-            symbol: symbol,
-            documentation: meta.documentation,
-            signatureDocumentation: meta.signatureDocumentation,
-            kind: symbolKindFor(element)
-          ));
+              symbol: symbol,
+              documentation: meta.documentation,
+              signatureDocumentation: meta.signatureDocumentation,
+              kind: symbolKindFor(element)));
         }
       }
     }

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/error/error.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:package_config/package_config.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:scip_dart/src/kind_generator.dart';
 import 'package:scip_dart/src/metadata.dart';
 import 'package:scip_dart/src/gen/scip.pb.dart';
 import 'package:scip_dart/src/relationship_generator.dart';
@@ -145,6 +146,7 @@ class ScipVisitor extends GeneralizingAstVisitor {
             symbol: symbol,
             documentation: meta.documentation,
             signatureDocumentation: meta.signatureDocumentation,
+            kind: symbolKindFor(element)
           ));
         }
       }
@@ -170,6 +172,7 @@ class ScipVisitor extends GeneralizingAstVisitor {
       documentation: meta.documentation,
       relationships: relationships,
       signatureDocumentation: meta.signatureDocumentation,
+      kind: symbolKindFor(element),
     ));
 
     occurrences.add(Occurrence(


### PR DESCRIPTION
Currently, indexed symbols are just the symbol as declared by the [scip spec](https://github.com/sourcegraph/scip/blob/main/scip.proto#L154)

This implies there's no way to tell the difference between a `class Foo` symbol, a `mixin Foo` symbol, and a `extension Foo` symbol

This PR populates the `kind` field on the scip symbol to resolve this, and enable deeper information about each indexed symbol provided by scip-dart

## QA

- Kind is not currently included within snapshot results, lets index the snapshot directory and manually verify `kind` using `scip print`
- Once https://github.com/sourcegraph/scip/pull/236 is merged, I'll consider adding `kind` annotation selections so we can write targeted unit tests for this concept