### PR TITLE
FEDX-1471 Release scip-dart 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+- Adds support for SymbolInformation.kind on the following symbols: class, enum, type alias, constructor, method, function, variable, parameter, property, and field.
+
 ## 1.4.4
 - Minor update to release CI
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.4.4';
+const scipDartVersion = '1.5.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.4.4
+version: 1.5.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump Workiva/gha-dart-oss from 0.1.2 to 0.1.3](https://github.com/Workiva/scip-dart/pull/141)
	* [Bump dart_dev from 4.1.1 to 4.2.0](https://github.com/Workiva/scip-dart/pull/142)
	* [Bump Workiva/gha-dart-oss from 0.1.3 to 0.1.5](https://github.com/Workiva/scip-dart/pull/143)
	* [Bump Workiva/gha-dart-oss from 0.1.5 to 0.1.6](https://github.com/Workiva/scip-dart/pull/145)
	* [FEDX-1648: Added symbol kind support](https://github.com/Workiva/scip-dart/pull/146)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.4.4...Workiva:release_scip-dart_1.5.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.4.4...1.5.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=148)