### PR TITLE
FEDX-1670: Fixed getters, setters, and field relationships

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,17 +15,8 @@ jobs:
   checks:
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.6
 
-  sbom:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 2.19.6
-      - uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          format: cyclonedx-json
+  build:
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.6
 
   snapshots:
     runs-on: ubuntu-latest

--- a/lib/src/relationship_generator.dart
+++ b/lib/src/relationship_generator.dart
@@ -27,13 +27,22 @@ List<Relationship>? relationshipsFor(
 
   // Since mixins do not support inheritance, we only care about
   // methods that exist on classes
-  if (node is MethodDeclaration && node.parent is ClassDeclaration) {
-    final parentNode = node.parent as ClassDeclaration?;
+  if (element is MethodElement || element is FieldElement || element is PropertyAccessorElement) {
+    final parentNode = node.thisOrAncestorOfType<ClassDeclaration>();
     final parentElement = parentNode?.declaredElement;
 
     // this shouldn't happen, but if the parent element happens to be
     // null, just fail fast
     if (parentElement == null) return null;
+
+    late final String name;
+    if (node is MethodDeclaration) {
+      name = node.name.toString();
+    } else if (element is FieldElement) {
+      name = element.name;
+    } else if (element is PropertyAccessorElement) {
+      name = element.name;
+    }
 
     // retrieve all of the methods and accessors of every parent type that
     // has the same name of [node]. These are the elements that this [node]
@@ -41,7 +50,7 @@ List<Relationship>? relationshipsFor(
     final referencingElements = parentElement.allSupertypes
         .map((type) => [...type.methods, ...type.accessors])
         .expand((type) => type)
-        .where((type) => type.name == node.name.toString());
+        .where((type) => type.name == name);
 
     if (referencingElements.isNotEmpty) {
       return referencingElements

--- a/lib/src/relationship_generator.dart
+++ b/lib/src/relationship_generator.dart
@@ -36,19 +36,17 @@ List<Relationship>? relationshipsFor(
     if (parentElement == null) return null;
 
     late final String name;
-    if (node is MethodDeclaration) {
-      name = node.name.toString();
-    } else if (element is FieldElement) {
-      name = element.name;
-    } else if (element is PropertyAccessorElement) {
-      name = element.name;
+    if (element is PropertyAccessorElement) {
+      name = element.variable.name;
+    } else {
+      name = element.name.toString();
     }
 
     // retrieve all of the methods and accessors of every parent type that
     // has the same name of [node]. These are the elements that this [node]
     // are overriding
     final referencingElements = parentElement.allSupertypes
-        .map((type) => [...type.methods, ...type.accessors])
+        .map((type) => [...type.methods, ...type.accessors.map((a) => a.variable)])
         .expand((type) => type)
         .where((type) => type.name == name);
 

--- a/lib/src/relationship_generator.dart
+++ b/lib/src/relationship_generator.dart
@@ -27,7 +27,9 @@ List<Relationship>? relationshipsFor(
 
   // Since mixins do not support inheritance, we only care about
   // methods that exist on classes
-  if (element is MethodElement || element is FieldElement || element is PropertyAccessorElement) {
+  if (element is MethodElement ||
+      element is FieldElement ||
+      element is PropertyAccessorElement) {
     final parentNode = node.thisOrAncestorOfType<ClassDeclaration>();
     final parentElement = parentNode?.declaredElement;
 
@@ -38,20 +40,21 @@ List<Relationship>? relationshipsFor(
     late final Iterable<Element> referencingElements;
     if (element is MethodElement) {
       referencingElements = parentElement.allSupertypes
-        .expand((type) => type.methods)
-        .where((type) => type.name == element.name);
+          .expand((type) => type.methods)
+          .where((type) => type.name == element.name);
     } else if (element is FieldElement) {
       referencingElements = parentElement.allSupertypes
-        .expand((type) => type.accessors)
-        .map((acc) => acc.variable)
-        .where((variable) => variable.name == element.name)
-        .toSet(); // remove any duplicates caused from synthetic getters/setters
-    } if (element is PropertyAccessorElement) {
+          .expand((type) => type.accessors)
+          .map((acc) => acc.variable)
+          .where((variable) => variable.name == element.name)
+          .toSet(); // remove any duplicates caused from synthetic getters/setters
+    }
+    if (element is PropertyAccessorElement) {
       referencingElements = parentElement.allSupertypes
-        .expand((type) => type.accessors)
-        .where((acc) => acc.isSetter == element.isSetter)
-        .where((acc) => acc.isGetter == element.isGetter)
-        .where((acc) => acc.variable.name == element.variable.name);
+          .expand((type) => type.accessors)
+          .where((acc) => acc.isSetter == element.isSetter)
+          .where((acc) => acc.isGetter == element.isGetter)
+          .where((acc) => acc.variable.name == element.variable.name);
     }
 
     return referencingElements

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -260,7 +260,8 @@ class SymbolGenerator {
       return [
         '$namespace/',
         if (parentName != null) '$parentName#',
-        '${element.name}.'
+        if (element.isGetter) '`<get>${element.name}`.',
+        if (element.isSetter) '`<set>${element.name.replaceFirst('=', '')}`.',
       ].join();
     }
 

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -257,11 +257,18 @@ class SymbolGenerator {
 
     if (element is PropertyAccessorElement) {
       final parentName = element.enclosingElement.name;
+
+      var prefix = '';
+      if (element.isGetter) {
+        prefix = '<get>';
+      } else if (element.isSetter) {
+        prefix = '<set>';
+      }
+
       return [
         '$namespace/',
         if (parentName != null) '$parentName#',
-        if (element.isGetter) '`<get>${element.name}`.',
-        if (element.isSetter) '`<set>${element.name.replaceFirst('=', '')}`.',
+        '`$prefix${element.variable.name}`.',
       ].join();
     }
 

--- a/snapshots/input/basic-project/lib/relationships.dart
+++ b/snapshots/input/basic-project/lib/relationships.dart
@@ -1,9 +1,13 @@
 abstract class Mammal {
-  String get hierarchy;
+  String get getter;
+  String field = '';
 }
 
 abstract class Animal extends Mammal {
   String sound() => 'NOISE!';
+
+  @override
+  String field = 'asdf';
 }
 
 mixin SwimAction {
@@ -12,8 +16,11 @@ mixin SwimAction {
 
 class Dog extends Animal with SwimAction {
   @override
+  String field = 'otherVal';
+
+  @override
   String sound() => 'woof';
 
   @override
-  String get hierarchy => 'dog.animal.mammal';
+  String get getter => 'value';
 }

--- a/snapshots/input/basic-project/lib/relationships.dart
+++ b/snapshots/input/basic-project/lib/relationships.dart
@@ -1,5 +1,6 @@
 abstract class Mammal {
-  String get getter;
+  String get someGetter;
+  set someSetter(String v);
   String field = '';
 }
 
@@ -22,5 +23,8 @@ class Dog extends Animal with SwimAction {
   String sound() => 'woof';
 
   @override
-  String get getter => 'value';
+  String get someGetter => 'value';
+
+  @override
+  set someSetter(String v) {};
 }

--- a/snapshots/output/basic-project/lib/relationships.dart
+++ b/snapshots/output/basic-project/lib/relationships.dart
@@ -1,9 +1,13 @@
   abstract class Mammal {
 // definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/
 //               ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#
-    String get getter;
+    String get someGetter;
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//             ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>getter`.
+//             ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>someGetter`.
+    set someSetter(String v);
+//      ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<set>someSetter`.
+//                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
+//                        ^ definition local 0
     String field = '';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field.
@@ -22,7 +26,8 @@
     String field = 'asdf';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field.
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>field`. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
   }
   
   mixin SwimAction {
@@ -44,8 +49,10 @@
     String field = 'otherVal';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#field.
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#`<get>field`. implementation reference
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>field`. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
   
     @override
 //   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
@@ -56,8 +63,16 @@
   
     @override
 //   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
-    String get getter => 'value';
+    String get someGetter => 'value';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//             ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<get>getter`.
-//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>getter`. implementation reference
+//             ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<get>someGetter`.
+//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#someGetter. implementation reference
+  
+    @override
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
+    set someSetter(String v) {};
+//      ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<set>someSetter`.
+//      relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#someSetter. implementation reference
+//                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
+//                        ^ definition local 1
   }

--- a/snapshots/output/basic-project/lib/relationships.dart
+++ b/snapshots/output/basic-project/lib/relationships.dart
@@ -27,7 +27,6 @@
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field.
 //         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
   }
   
   mixin SwimAction {
@@ -50,8 +49,6 @@
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#field.
 //         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field. implementation reference
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field. implementation reference
-//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
 //         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field. implementation reference
   
     @override
@@ -66,13 +63,13 @@
     String get someGetter => 'value';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //             ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<get>someGetter`.
-//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#someGetter. implementation reference
+//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>someGetter`. implementation reference
   
     @override
 //   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
     set someSetter(String v) {};
 //      ^^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<set>someSetter`.
-//      relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#someSetter. implementation reference
+//      relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<set>someSetter`. implementation reference
 //                 ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //                        ^ definition local 1
   }

--- a/snapshots/output/basic-project/lib/relationships.dart
+++ b/snapshots/output/basic-project/lib/relationships.dart
@@ -1,9 +1,12 @@
   abstract class Mammal {
 // definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/
 //               ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#
-    String get hierarchy;
+    String get getter;
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//             ^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#hierarchy.
+//             ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>getter`.
+    String field = '';
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
+//         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#field.
   }
   
   abstract class Animal extends Mammal {
@@ -13,6 +16,13 @@
     String sound() => 'NOISE!';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#sound().
+  
+    @override
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
+    String field = 'asdf';
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
+//         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#field.
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>field`. implementation reference
   }
   
   mixin SwimAction {
@@ -31,6 +41,14 @@
 //                              ^^^^^^^^^^ reference scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/SwimAction#
     @override
 //   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
+    String field = 'otherVal';
+//  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
+//         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#field.
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Animal#`<get>field`. implementation reference
+//         relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>field`. implementation reference
+  
+    @override
+//   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
     String sound() => 'woof';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
 //         ^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#sound().
@@ -38,8 +56,8 @@
   
     @override
 //   ^^^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`annotations.dart`/override.
-    String get hierarchy => 'dog.animal.mammal';
+    String get getter => 'value';
 //  ^^^^^^ reference scip-dart pub dart:core 2.19.0 dart:core/`string.dart`/String#
-//             ^^^^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#hierarchy.
-//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#hierarchy. implementation reference
+//             ^^^^^^ definition scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Dog#`<get>getter`.
+//             relationship scip-dart pub dart_test 1.0.0 lib/`relationships.dart`/Mammal#`<get>getter`. implementation reference
   }


### PR DESCRIPTION
# [FEDX-1670](https://jira.atl.workiva.net/browse/FEDX-1670)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1670)

getters, setters, and fields were not correctly indexing their relationships. This PR fixes that (Closes #151)

Also closes #119, because that was necessary in order to get the relationships fixed