### PR TITLE
FEDX-1660 Release scip-dart 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.2
+- Improved support for getters/setters, utilizing `<get>`/`<set>` keywords within indexed symbols
+- Fixed relationship indexing for fields, getters, and setters
+
 ## 1.5.1
 - Adds support for missing SymbolInformation.kind on extension, mixin symbols
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.5.1';
+const scipDartVersion = '1.5.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.5.1
+version: 1.5.2
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-1670: Fixed getters, setters, and field relationships](https://github.com/Workiva/scip-dart/pull/152)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.5.1...Workiva:release_scip-dart_1.5.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.5.1...1.5.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=154)