### PR TITLE
raise_min_dart_sdk_2_19

### DIFF
--- a/snapshots/input/basic-project/pubspec.yaml
+++ b/snapshots/input/basic-project/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_test
 version: 1.0.0
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   test: ^1.24.3

--- a/snapshots/input/diagnostics/pubspec.yaml
+++ b/snapshots/input/diagnostics/pubspec.yaml
@@ -2,6 +2,6 @@ name: dart_test_diagnostics
 version: 1.0.0
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: '>=2.19.0 <3.0.0'
 dependencies:
   lints: ^2.0.1

--- a/snapshots/input/staging-project/pubspec.yaml
+++ b/snapshots/input/staging-project/pubspec.yaml
@@ -2,4 +2,4 @@ name: dart_test
 version: 1.0.0
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: '>=2.19.0 <3.0.0'


### PR DESCRIPTION
# Summary
For Dart packages that have migrated to null safety (full or partial)
we can raise the minimum Dart SDK version to 2.19.0 instead of 2.12.0.
This will allow us to take advantage of new language features as soon as
files are migrated to null safety. We've shown that unmigrated consumers
do not have issues consuming packages with a higher minimum Dart SDK version.
# Changes
- Raise minimum Dart SDK version to 2.19.0
# QA
- [ ] CI passes

[_Created by Sourcegraph batch change `Workiva/raise_min_dart_sdk_2_19`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/raise_min_dart_sdk_2_19)