### PR TITLE
FEDX-1674 Release scip-dart 1.5.3

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.5.2';
+const scipDartVersion = '1.5.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.5.2
+version: 1.5.3
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump workiva_analysis_options from 1.4.1 to 1.4.2](https://github.com/Workiva/scip-dart/pull/156)
	* [Bump Workiva/gha-dart-oss from 0.1.6 to 0.1.7](https://github.com/Workiva/scip-dart/pull/157)
	* [Bump dart_dev from 4.2.0 to 4.2.2](https://github.com/Workiva/scip-dart/pull/158)
	* [raise_min_dart_sdk_2_19](https://github.com/Workiva/scip-dart/pull/159)


Requested by: @robbecker-wf

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.5.2...Workiva:release_scip-dart_1.5.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.5.2...1.5.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=160)