### PR TITLE
FEDX-2113 Release scip-dart 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.4
+- Fixed a bug where constructor references weren't correctly indexed
+
+## 1.5.3
+- Dependency bumps
+
 ## 1.5.2
 - Improved support for getters/setters, utilizing `<get>`/`<set>` keywords within indexed symbols
 - Fixed relationship indexing for fields, getters, and setters

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.5.3';
+const scipDartVersion = '1.5.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.5.3
+version: 1.5.4
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump workiva_analysis_options from 1.4.2 to 1.4.3](https://github.com/Workiva/scip-dart/pull/161)
	* [Bump dependency_validator from 4.1.0 to 4.1.2](https://github.com/Workiva/scip-dart/pull/162)
	* [FEDX-2227: Fixed logic for constructor references](https://github.com/Workiva/scip-dart/pull/165)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.5.3...Workiva:release_scip-dart_1.5.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.5.3...1.5.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=167)