### PR TITLE
FEDX-2340 Release scip-dart 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+- Added `--output` flag to configure output location of the generated index file 
+
 ## 1.5.4
 - Fixed a bug where constructor references weren't correctly indexed
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.5.4';
+const scipDartVersion = '1.6.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.5.4
+version: 1.6.0
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [feat: --output flag](https://github.com/Workiva/scip-dart/pull/169)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.5.4...Workiva:release_scip-dart_1.6.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.5.4...1.6.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=170)