### PR TITLE
FEDX-2495 Release scip-dart 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.1
+- Added a default disabled flag for indexing pubspec.yaml files `--index-pubspec`. 
+
 ## 1.6.0
 - Added `--output` flag to configure output location of the generated index file 
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.6.0';
+const scipDartVersion = '1.6.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.6.0
+version: 1.6.1
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump dependency_validator from 4.1.2 to 4.1.3](https://github.com/Workiva/scip-dart/pull/171)
	* [Bump dart_dev from 4.2.2 to 4.2.3](https://github.com/Workiva/scip-dart/pull/172)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.6.0...Workiva:release_scip-dart_1.6.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.6.0...1.6.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5246720260440064/?repo_name=Workiva%2Fscip-dart&pull_number=174)