### PR TITLE
FEDX-2979: Pubspec Indexing followups

### DIFF
--- a/lib/src/pubspec_indexer.dart
+++ b/lib/src/pubspec_indexer.dart
@@ -34,7 +34,10 @@ Document indexPubspec({
   if (pubspec.publishTo != 'none') {
     final info = _buildFileSymbol(pubspec);
     symbols.add(info);
-    occurrences.add(Occurrence(symbol: info.symbol, range: [0, 0, 0],));
+    occurrences.add(Occurrence(
+      symbol: info.symbol,
+      range: [0, 0, 0],
+    ));
   }
 
   final deps = {

--- a/lib/src/pubspec_indexer.dart
+++ b/lib/src/pubspec_indexer.dart
@@ -36,6 +36,7 @@ Document indexPubspec({
     symbols.add(info);
     occurrences.add(Occurrence(
       symbol: info.symbol,
+      symbolRoles: SymbolRole.Definition.value,
       range: [0, 0, 0],
     ));
   }

--- a/lib/src/pubspec_indexer.dart
+++ b/lib/src/pubspec_indexer.dart
@@ -28,7 +28,7 @@ Document indexPubspec({
     'scip-dart',
     'pub',
     pubspec.name,
-    pubspec.version!,
+    pubspec.version ?? '*',
     '`pubspec.yaml`/',
   ].join(' ');
 

--- a/snapshots/output/basic-project/pubspec.yaml
+++ b/snapshots/output/basic-project/pubspec.yaml
@@ -1,5 +1,5 @@
   name: dart_test
-// reference scip-dart pub dart_test 1.0.0 `pubspec.yaml`/
+// definition scip-dart pub dart_test 1.0.0 `pubspec.yaml`/
   version: 1.0.0
   
   environment:

--- a/snapshots/output/diagnostics/pubspec.yaml
+++ b/snapshots/output/diagnostics/pubspec.yaml
@@ -1,5 +1,5 @@
   name: dart_test_diagnostics
-// reference scip-dart pub dart_test_diagnostics 1.0.0 `pubspec.yaml`/
+// definition scip-dart pub dart_test_diagnostics 1.0.0 `pubspec.yaml`/
   version: 1.0.0
   
   environment:


### PR DESCRIPTION
# [FEDX-2979](https://jira.atl.workiva.net/browse/FEDX-2979)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-2979)

- `version` is optional within a pubspec file, when its missing scip-dart will hard-fail on a NPE. We should cover this edge case since it is indeed optional. For the cases where the version is missing, use the scip wildcard field
- `publish_to: none` in a pubspec.yaml file implies that the pubspec should not be published. In an effort to not encounter many duplicates caused from this, we should consider `publish_to: none` an indication that no other pubspecs will be referencing this one, so we can omit the file symbol