### PR TITLE
Release scip-dart 1.6.2

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -2,4 +2,4 @@
 // stored within pubspec.yaml
 
 /// The current version of scip_dart
-const scipDartVersion = '1.6.1';
+const scipDartVersion = '1.6.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scip_dart
-version: 1.6.1
+version: 1.6.2
 description: generates scip bindings for dart files
 repository: https://github.com/Workiva/scip-dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-3240: Support Dart v3](https://github.com/Workiva/scip-dart/pull/116)
	* [FEDX-2979: Pubspec Indexing followups](https://github.com/Workiva/scip-dart/pull/175)


Requested by: @matthewnitschke-wk

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/scip-dart/compare/1.6.1...Workiva:release_scip-dart_1.6.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/scip-dart/compare/1.6.1...1.6.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5246720260440064/logs/)