### PR TITLE
Fixed enclosing_range calculation

### DIFF
--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -180,7 +180,7 @@ class ScipVisitor extends GeneralizingAstVisitor {
       symbol: symbol,
       symbolRoles: SymbolRole.Definition.value,
       diagnostics: meta.diagnostics,
-      enclosingRange: _lineInfo.getRange(node.offset, node.end),
+      enclosingRange: _lineInfo.getRange(node.offset, node.length),
     ));
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -33,9 +33,9 @@ void display(String input, {DisplayLevel level = DisplayLevel.warn}) {
 }
 
 extension LineInfoExtension on LineInfo {
-  List<int> getRange(int offset, int nameLength) {
+  List<int> getRange(int offset, int length) {
     final start = getLocation(offset);
-    final end = getLocation(offset + nameLength);
+    final end = getLocation(offset + length);
 
     final res = [
       start.lineNumber - 1,


### PR DESCRIPTION
The enclosing range on occurrences wasn't getting calculated correctly. Notably, `node.end` is the _offset_ of the node's end, and `getRange` expects the length of the node as the input

This PR updates this