### PR TITLE
FEDX-4269: Added publish_to: none for test fixtures

### DIFF
--- a/snapshots/input/basic-project/pubspec.lock
+++ b/snapshots/input/basic-project/pubspec.lock
@@ -362,4 +362,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0 <3.0.0"

--- a/snapshots/input/basic-project/pubspec.yaml
+++ b/snapshots/input/basic-project/pubspec.yaml
@@ -1,5 +1,6 @@
 name: dart_test
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=2.19.0 <3.0.0'

--- a/snapshots/input/dart3-features/pubspec.yaml
+++ b/snapshots/input/dart3-features/pubspec.yaml
@@ -1,5 +1,6 @@
 name: dart3_features
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/snapshots/input/diagnostics/pubspec.lock
+++ b/snapshots/input/diagnostics/pubspec.lock
@@ -10,4 +10,4 @@ packages:
     source: hosted
     version: "2.0.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0 <3.0.0"

--- a/snapshots/input/diagnostics/pubspec.yaml
+++ b/snapshots/input/diagnostics/pubspec.yaml
@@ -1,5 +1,6 @@
 name: dart_test_diagnostics
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=2.19.0 <3.0.0'

--- a/snapshots/input/staging-project/pubspec.yaml
+++ b/snapshots/input/staging-project/pubspec.yaml
@@ -1,5 +1,6 @@
 name: dart_test
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=2.19.0 <3.0.0'

--- a/snapshots/output/basic-project/pubspec.yaml
+++ b/snapshots/output/basic-project/pubspec.yaml
@@ -1,6 +1,6 @@
   name: dart_test
-// definition scip-dart pub dart_test 1.0.0 `pubspec.yaml`/
   version: 1.0.0
+  publish_to: none
   
   environment:
     sdk: '>=2.19.0 <3.0.0'

--- a/snapshots/output/dart3-features/pubspec.yaml
+++ b/snapshots/output/dart3-features/pubspec.yaml
@@ -1,6 +1,6 @@
   name: dart3_features
-// definition scip-dart pub dart3_features 1.0.0 `pubspec.yaml`/
   version: 1.0.0
+  publish_to: none
   
   environment:
     sdk: ">=3.0.0 <4.0.0"

--- a/snapshots/output/diagnostics/pubspec.yaml
+++ b/snapshots/output/diagnostics/pubspec.yaml
@@ -1,6 +1,6 @@
   name: dart_test_diagnostics
-// definition scip-dart pub dart_test_diagnostics 1.0.0 `pubspec.yaml`/
   version: 1.0.0
+  publish_to: none
   
   environment:
     sdk: '>=2.19.0 <3.0.0'


### PR DESCRIPTION
# [FEDX-4269](https://jira.atl.workiva.net/browse/FEDX-4269)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-4269)

Added `publish_to: none` for test fixtures

They shouldn't be published, and adding this ensures they wont be